### PR TITLE
Invocations redesign

### DIFF
--- a/Invocation/Invocation.xcodeproj/project.pbxproj
+++ b/Invocation/Invocation.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		5907F910254B435100E3EF74 /* ChecklistsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5907F90F254B435100E3EF74 /* ChecklistsView.swift */; };
 		5907F915254B463C00E3EF74 /* ChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5907F914254B463C00E3EF74 /* ChecklistView.swift */; };
 		5913C1F4254F439200A00F51 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5913C1F3254F439200A00F51 /* CloudKit.framework */; };
+		5928C42C257996560089C603 /* CollapseController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5928C42B257996560089C603 /* CollapseController.swift */; };
+		5928C4312579A2830089C603 /* Set+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5928C4302579A2830089C603 /* Set+Convenience.swift */; };
 		59331B792559E78800F14270 /* TaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59331B782559E78800F14270 /* TaskView.swift */; };
 		593591092551D22100695B43 /* Invocation+Delete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593591082551D22100695B43 /* Invocation+Delete.swift */; };
 		597C95DF25547A2400A9A9D4 /* AcknowledgementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597C95DE25547A2400A9A9D4 /* AcknowledgementsView.swift */; };
@@ -77,6 +79,8 @@
 		5907F914254B463C00E3EF74 /* ChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistView.swift; sourceTree = "<group>"; };
 		5913C1EE254F438F00A00F51 /* Invocation.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Invocation.entitlements; sourceTree = "<group>"; };
 		5913C1F3254F439200A00F51 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
+		5928C42B257996560089C603 /* CollapseController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapseController.swift; sourceTree = "<group>"; };
+		5928C4302579A2830089C603 /* Set+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Convenience.swift"; sourceTree = "<group>"; };
 		59331B782559E78800F14270 /* TaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskView.swift; sourceTree = "<group>"; };
 		593591082551D22100695B43 /* Invocation+Delete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Invocation+Delete.swift"; sourceTree = "<group>"; };
 		597C95DE25547A2400A9A9D4 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
@@ -199,6 +203,7 @@
 				593591082551D22100695B43 /* Invocation+Delete.swift */,
 				59AA3389255340C6009D3096 /* Defaults.swift */,
 				597C95E32554866C00A9A9D4 /* ObjectsContainer.swift */,
+				5928C4302579A2830089C603 /* Set+Convenience.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -225,6 +230,7 @@
 			children = (
 				5907F8D6254B3E9D00E3EF74 /* Persistence.swift */,
 				59C4AEA62550885400A4438A /* ChecklistController.swift */,
+				5928C42B257996560089C603 /* CollapseController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -402,6 +408,7 @@
 				59AF3F472552163700F76C9D /* ProjectView.swift in Sources */,
 				59C00842254DDE5A00E33D98 /* Invocation+FetchRequest.swift in Sources */,
 				5907F8DA254B3E9D00E3EF74 /* Invocation.xcdatamodeld in Sources */,
+				5928C42C257996560089C603 /* CollapseController.swift in Sources */,
 				59C4AEA225507EC700A4438A /* ItemView.swift in Sources */,
 				5907F910254B435100E3EF74 /* ChecklistsView.swift in Sources */,
 				5907F915254B463C00E3EF74 /* ChecklistView.swift in Sources */,
@@ -411,6 +418,7 @@
 				59C4AEAD25509F6A00A4438A /* ProjectsView.swift in Sources */,
 				5907F8CE254B3E9B00E3EF74 /* InvocationApp.swift in Sources */,
 				597C95DF25547A2400A9A9D4 /* AcknowledgementsView.swift in Sources */,
+				5928C4312579A2830089C603 /* Set+Convenience.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Invocation/Invocation/Controllers/ChecklistController.swift
+++ b/Invocation/Invocation/Controllers/ChecklistController.swift
@@ -146,6 +146,12 @@ class ChecklistController: ObservableObject {
     
     //MARK: Project/Task CRUD
     
+    func invoke(_ checklist: Checklist, context: NSManagedObjectContext) -> Project {
+        let project = Project(checklist: checklist, context: context)
+        createNotifications(for: project)
+        return project
+    }
+    
     func delete(_ project: Project, context: NSManagedObjectContext) {
         if let tasks = project.tasks as? Set<Task> {
             let notificationIDs = tasks.compactMap { $0.notificationID?.uuidString }

--- a/Invocation/Invocation/Controllers/CollapseController.swift
+++ b/Invocation/Invocation/Controllers/CollapseController.swift
@@ -1,0 +1,42 @@
+//
+//  CollapseController.swift
+//  Invocation
+//
+//  Created by Isaac Lyons on 12/3/20.
+//
+
+import SwiftUI
+
+class CollapseController<T: Hashable>: ObservableObject {
+    @Published var collapsed: Set<T> = []
+    @Published var collapseQueue: Set<T> = []
+    private var collapsing = false
+    
+    @discardableResult
+    func toggle(_ object: T) -> Bool {
+        if !collapsing {
+            startCollapsing()
+            withAnimation {
+                collapsed.toggle(object)
+            }
+        } else {
+            collapseQueue.insert(object)
+        }
+        return collapsed.contains(object) ? !collapseQueue.contains(object) : collapseQueue.contains(object)
+    }
+    
+    private func startCollapsing() {
+        collapsing = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+            guard let self = self else { return }
+            self.collapsing = false
+            if !self.collapseQueue.isEmpty {
+                self.startCollapsing()
+                withAnimation {
+                    self.collapseQueue.forEach { self.collapsed.toggle($0) }
+                }
+                self.collapseQueue.removeAll()
+            }
+        }
+    }
+}

--- a/Invocation/Invocation/Model/Set+Convenience.swift
+++ b/Invocation/Invocation/Model/Set+Convenience.swift
@@ -1,0 +1,18 @@
+//
+//  Set+Convenience.swift
+//  Invocation
+//
+//  Created by Isaac Lyons on 12/3/20.
+//
+
+import Foundation
+
+extension Set {
+    mutating func toggle(_ member: Element) {
+        if contains(member) {
+            remove(member)
+        } else {
+            insert(member)
+        }
+    }
+}

--- a/Invocation/Invocation/Views/ChecklistView.swift
+++ b/Invocation/Invocation/Views/ChecklistView.swift
@@ -118,9 +118,7 @@ struct ChecklistView: View {
     }
     
     private func invoke() {
-        let project = Project(checklist: checklist, context: moc)
-        self.project = project
-        checklistController.createNotifications(for: project)
+        project = checklistController.invoke(checklist, context: moc)
     }
 }
 

--- a/Invocation/Invocation/Views/ProjectView.swift
+++ b/Invocation/Invocation/Views/ProjectView.swift
@@ -217,13 +217,6 @@ fileprivate struct TaskRow: View {
     
     var body: some View {
         HStack {
-            NavigationLink(
-                destination: TaskView(task: task),
-                tag: task,
-                selection: $selection,
-                label: { EmptyView() })
-                .frame(width: 0, height: 0)
-            
             Button {
                 task.toggle()
             } label: {
@@ -256,6 +249,14 @@ fileprivate struct TaskRow: View {
                 Image(systemName: "questionmark.circle")
                     .imageScale(.large)
             }
+            
+            NavigationLink(
+                destination: TaskView(task: task),
+                tag: task,
+                selection: $selection,
+                label: { EmptyView() })
+                .frame(width: 0, height: 0)
+                .opacity(0)
         }
         .buttonStyle(BorderlessButtonStyle())
     }

--- a/Invocation/Invocation/Views/ProjectView.swift
+++ b/Invocation/Invocation/Views/ProjectView.swift
@@ -29,16 +29,19 @@ struct ProjectView: View {
     
     @ObservedObject var project: Project
     
+    var markForDelete: (Project) -> Void
+    
     @State private var title: String = ""
     @State private var selection: Task?
     @State private var delete = false
     @State private var showOne = false
     
-    init(project: Project) {
+    init(project: Project, markForDelete: @escaping (Project) -> Void = {_ in}) {
         self.project = project
         self.tasksFetchRequest = FetchRequest(
             fetchRequest: project.allTasksFetchRequest(),
             animation: .default)
+        self.markForDelete = markForDelete
     }
     
     //MARK: Views
@@ -180,6 +183,7 @@ struct ProjectView: View {
     }
     
     func deleteProject() {
+        markForDelete(project)
         presentationMode.wrappedValue.dismiss()
         checklistController.delete(project, context: moc)
     }

--- a/Invocation/Invocation/Views/ProjectsView.swift
+++ b/Invocation/Invocation/Views/ProjectsView.swift
@@ -331,6 +331,7 @@ struct ProjectsView_Previews: PreviewProvider {
             ProjectsView(tab: .constant(0))
                 .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
                 .environmentObject(projectsContainer)
+                .environmentObject(ChecklistController())
         }
     }
 }

--- a/Invocation/Invocation/Views/ProjectsView.swift
+++ b/Invocation/Invocation/Views/ProjectsView.swift
@@ -97,7 +97,8 @@ fileprivate struct ProjectSection: View {
                     Text(project.wrappedTitle ??? "Project")
                         .font(.title)
                         .foregroundColor(.primary)
-                    Text("\(project.tasks?.count ?? 0) Tasks")
+                    Text("\(project.tasks?.count ?? 0) Task\(project.tasks?.count == 1 ? "" : "s")")
+                        .font(.subheadline)
                         .foregroundColor(.secondary)
                     Spacer()
                 }
@@ -108,23 +109,28 @@ fileprivate struct ProjectSection: View {
                     .rotationEffect(expanded ? .degrees(90) : .zero)
             }
         }
-        .textCase(.none)
     }
     
     private var footer: some View {
         HStack {
             Spacer()
-            Button {
-                selection = project
-            } label: {
+            HStack {
                 Text("Details")
                 Image(systemName: "chevron.forward")
+            }
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+            .padding(.trailing)
+            .onTapGesture {
+                selection = project
             }
         }
     }
     
     var body: some View {
-        Section(header: header, footer: footer) {
+        Group {
+            header
+                .listRowBackground(Color(.systemGroupedBackground))
             if expanded {
                 if !project.showOne {
                     ForEach(tasks) { task in
@@ -136,6 +142,10 @@ fileprivate struct ProjectSection: View {
                     }
                 }
             }
+            footer
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                .listRowInsets(EdgeInsets())
+                .background(Color(.systemGroupedBackground))
         }
     }
 }

--- a/Invocation/Invocation/Views/ProjectsView.swift
+++ b/Invocation/Invocation/Views/ProjectsView.swift
@@ -23,6 +23,14 @@ struct ProjectsView: View {
     @State private var selection: Project?
     @State private var toDelete: Project?
     
+    var emptyHeader: some View {
+        EmptyView()
+            .padding(.trailing)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .listRowInsets(EdgeInsets())
+            .background(Color(.systemGroupedBackground))
+    }
+    
     var body: some View {
         Group {
             if projects.count == 0 {
@@ -37,9 +45,11 @@ struct ProjectsView: View {
                 }
             } else {
                 List {
-                    ForEach(projects) { project in
-                        if project != toDelete {
-                            ProjectSection(project: project, selection: $selection)
+                    Section(header: emptyHeader, footer: footer(projects.last)) {
+                        ForEach(projects) { project in
+                            if project != toDelete {
+                                ProjectSection(project: project, selection: $selection, last: project == projects.last)
+                            }
                         }
                     }
                 }
@@ -67,6 +77,21 @@ struct ProjectsView: View {
             toDelete = project
         }
     }
+    
+    private func footer(_ project: Project?) -> some View {
+        HStack {
+            Spacer()
+            HStack {
+                Text("Details")
+                Image(systemName: "chevron.forward")
+            }
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+            .onTapGesture {
+                selection = project
+            }
+        }
+    }
 }
 
 //MARK: Project Section
@@ -85,14 +110,17 @@ fileprivate struct ProjectSection: View {
     @ObservedObject var project: Project
     
     @Binding var selection: Project?
+    var last: Bool
+    
     @State private var expanded = true
     
-    init(project: Project, selection: Binding<Project?>) {
+    init(project: Project, selection: Binding<Project?>, last: Bool) {
         self.project = project
         _selection = selection
         tasksFetchRequest = FetchRequest(
             fetchRequest: project.tasksFetchRequest(),
             animation: .default)
+        self.last = last
     }
     
     private var header: some View {
@@ -151,12 +179,14 @@ fileprivate struct ProjectSection: View {
                     }
                 }
             }
-            footer
-                // This removes the separator line from below the footer cell
-                .padding(.trailing)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                .listRowInsets(EdgeInsets())
-                .background(Color(.systemGroupedBackground))
+            if !last {
+                footer
+                    // This removes the separator line from below the footer cell
+                    .padding(.trailing)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                    .listRowInsets(EdgeInsets())
+                    .background(Color(.systemGroupedBackground))
+            }
         }
     }
 }

--- a/Invocation/Invocation/Views/ProjectsView.swift
+++ b/Invocation/Invocation/Views/ProjectsView.swift
@@ -21,6 +21,7 @@ struct ProjectsView: View {
     @Binding var tab: Int
     
     @State private var selection: Project?
+    @State private var toDelete: Project?
     
     var body: some View {
         Group {
@@ -37,7 +38,9 @@ struct ProjectsView: View {
             } else {
                 List {
                     ForEach(projects) { project in
-                        ProjectSection(project: project, selection: $selection)
+                        if project != toDelete {
+                            ProjectSection(project: project, selection: $selection)
+                        }
                     }
                 }
             }
@@ -46,15 +49,22 @@ struct ProjectsView: View {
         .navigationTitle("Invocations")
         .sheet(item: $selection) { project in
             NavigationView {
-                ProjectView(project: project)
+                ProjectView(project: project, markForDelete: markForDelete)
             }
             .environment(\.managedObjectContext, moc)
             .environmentObject(checklistController)
+            // When the project view is dismissed, update its position in the list
             .onDisappear {
                 withAnimation {
                     projectsContainer.update(object: project)
                 }
             }
+        }
+    }
+    
+    private func markForDelete(_ project: Project) {
+        withAnimation(.none) {
+            toDelete = project
         }
     }
 }
@@ -120,7 +130,6 @@ fileprivate struct ProjectSection: View {
             }
             .font(.subheadline)
             .foregroundColor(.secondary)
-            .padding(.trailing)
             .onTapGesture {
                 selection = project
             }
@@ -143,6 +152,8 @@ fileprivate struct ProjectSection: View {
                 }
             }
             footer
+                // This removes the separator line from below the footer cell
+                .padding(.trailing)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .listRowInsets(EdgeInsets())
                 .background(Color(.systemGroupedBackground))

--- a/Invocation/Invocation/Views/ProjectsView.swift
+++ b/Invocation/Invocation/Views/ProjectsView.swift
@@ -46,6 +46,15 @@ struct ProjectsView: View {
                 }
             } else {
                 List {
+                    // What appear to be section headers and footers in this list are actually
+                    // just cells with their background color set to the grouped list background
+                    // color and their separator lines removed.
+                    // The issue is that this puts a line at the top and bottom of the list.
+                    // By putting the entire thing in a section, we can create a header with
+                    // its bottom line removed and use an actual footer for the last section
+                    // instead of the pseudo-footers used for the other sections. This allows
+                    // us to remove those extra separator lines at the top and bottom of the
+                    // list to make the pseudo-sections look more like actual sections.
                     Section(header: emptyHeader, footer: footer(projects.last)) {
                         ForEach(projects) { project in
                             if project != toDelete {
@@ -92,6 +101,7 @@ struct ProjectsView: View {
                 selection = project
             }
         }
+        .padding(.top, 8)
     }
 }
 
@@ -198,7 +208,6 @@ fileprivate struct ProjectSection: View {
                     .background(Color(.systemGroupedBackground))
             }
         }
-//        .animation(.easeInOut(duration: 0.125))
     }
 }
 


### PR DESCRIPTION
Replace the header and footers of the Invocations list with cells.
These cells have the same background color as the grouped list and have separator lines removed (at least the ones that I've been able to figure out how to remove).

This improves the animation of collapsing cells as the background of list section headers were transparent.